### PR TITLE
adding podcast main page and functions to enable podcast metadata

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -270,6 +270,54 @@ add_filter('embed_oembed_html', 'soundCloud_mini_embed', 10, 3);
 
 
 
+/////////////////////////////////
+// ADD CUSTOM FIELDS TO THE CUSTOM "PODCASTS" TAXONOMY
+/////////////////////////////////
+// http://sabramedia.com/blog/how-to-add-custom-fields-to-custom-taxonomies
+
+// A callback function to add a custom field to our "presenters" taxonomy
+function podcast_taxonomy_custom_fields($tax) {
+   // Check for existing taxonomy meta for the term you're editing
+    $t_id = $tax->term_id; // Get the ID of the term you're editing
+    $term_meta = get_option( "taxonomy_term_$t_id" ); // Do the check
+?>
+
+<tr class="form-field">
+	<th scope="row" valign="top">
+		<label for="podcast_itunes_link"><?php _e('URL for Podcast on iTunes'); ?></label>
+	</th>
+	<td>
+		<input type="text" name="term_meta[podcast_itunes_link]" id="term_meta[podcast_itunes_link]" size="25" style="width:60%;" value="<?php echo $term_meta['podcast_itunes_link'] ? $term_meta['podcast_itunes_link'] : ''; ?>"><br />
+		<span class="description"><?php _e('The link to the podcast on iTunes'); ?></span>
+	</td>
+</tr>
+
+<?php };
+
+// A callback function to save our extra taxonomy field(s)
+function save_taxonomy_custom_fields( $term_id ) {
+    if ( isset( $_POST['term_meta'] ) ) {
+        $t_id = $term_id;
+        $term_meta = get_option( "taxonomy_term_$t_id" );
+        $cat_keys = array_keys( $_POST['term_meta'] );
+            foreach ( $cat_keys as $key ){
+            if ( isset( $_POST['term_meta'][$key] ) ){
+                $term_meta[$key] = $_POST['term_meta'][$key];
+            }
+        }
+        //save the option array
+        update_option( "taxonomy_term_$t_id", $term_meta );
+    }
+}
+
+// Add the fields to the "podcasts" taxonomy, using our callback function
+add_action( 'podcast_edit_form_fields', 'podcast_taxonomy_custom_fields', 10, 2 );
+
+// Save the changes made on the "podcasts" taxonomy, using our callback function
+add_action( 'edited_podcast', 'save_taxonomy_custom_fields', 10, 2 );
+
+
+
 
 /////////////////////////////////
 // LIST AUTHORS OF CUSTOM POST TYPES

--- a/page-podcasts.php
+++ b/page-podcasts.php
@@ -1,0 +1,58 @@
+<?php get_header(); ?>
+<div class="main_content vertical_podcasts pure-g-r">
+	<!-- This is a default template page! -->
+  
+  <div class="pure-u-1">  
+  
+	<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+	
+	<h1><?php the_title(); ?></h1>
+	
+	<?php the_content(); ?>
+	
+	<?php endwhile; else: ?>
+  	<p><?php _e('Sorry, no posts matched your criteria.'); ?></p>
+	<?php endif; ?>
+	
+	
+	<hr />
+	
+	<?php
+	  
+	  $podcasts = get_terms( 'podcast' );
+  	
+  	foreach($podcasts as $podcast) {
+          	
+    	$podcastName = $podcast->name;
+    	$podcastSlug = $podcast->slug;
+    	$podcastID = $podcast->term_id;
+    	$podcastDesc = $podcast->description;
+    	$podcastURL = get_bloginfo('url') . "/podcast/" . $podcast->slug;
+    	
+    	// Get the podcast term's custom fields based on its ID. See functions.php for the code that controls the podcast term's custom fields
+    	// See also: http://sabramedia.com/blog/how-to-add-custom-fields-to-custom-taxonomies
+    	$podcast_custom_fields = get_option( "taxonomy_term_$podcast->term_id");    	
+      $podcastURLitunes = $podcast_custom_fields['podcast_itunes_link'];
+  
+  ?>    	
+    
+    <div class="podcast podcast-id-<?php echo $podcastID ?> podcast-<?php echo $podcastSlug ?>">
+      
+      <h2><a href="<?php echo $podcastURL ?>"><?php echo $podcastName ?></a></h2>
+      <?php if ( $podcastDesc ) { ?>
+      <p><?php echo $podcastDesc ?></p>
+      <?php } ?>
+      <?php if ( $podcastURLitunes ) { ?>
+      <p><small><a href="<?php echo $podcastURLitunes ?>">Subscribe in iTunes</a></small></p>
+      <?php } ?>
+      
+    </div>
+    	
+  
+  <?php }; // End foreach ?>
+	
+	
+  </div>
+
+</div>
+<?php get_footer(); ?>

--- a/single-podcast-episode.php
+++ b/single-podcast-episode.php
@@ -11,8 +11,8 @@
   	$podcastName = $podcast->name;
   	$podcastDesc = $podcast->description;
   	$podcastSlug = $podcast->slug;
-  	$podcastURL = get_bloginfo('home') . "/podcast/" . $podcastSlug;
-  	$podcastFeed = get_bloginfo('home') . "/podcast/" . $podcastSlug . "/feed";
+  	$podcastURL = get_bloginfo('url') . "/podcast/" . $podcastSlug;
+  	$podcastFeed = get_bloginfo('url') . "/podcast/" . $podcastSlug . "/feed";
   	
 	?>
 


### PR DESCRIPTION
Adds overall Podcast directory page to address #70. Also adds custom fields to the "Podcast" taxonomy to allow additional metadata on listings pages, e.g. iTunes URLs, etc.